### PR TITLE
Various fixes and cleanups

### DIFF
--- a/associators.js
+++ b/associators.js
@@ -66,7 +66,7 @@ const associationsForSimpleMapping = (mapping) => {
   const packageModuleMap = {};
   const modulePackageMap = {};
 
-  for (const primaryKey in mapping) {
+  for (const primaryKey of Object.keys(mapping)) {
     if (hasOwnProperty(packageModuleMap, primaryKey)) {
       throw new Error(`A packaging is for the primary key ${
         JSON.stringify(primaryKey)} is already defined.`);

--- a/associators.js
+++ b/associators.js
@@ -67,8 +67,7 @@ const associationsForSimpleMapping = (mapping) => {
   const moduleToBundle = {};
   for (const [bundle, modules] of Object.entries(mapping)) {
     if (hasOwnProperty(bundleToModules, bundle)) {
-      throw new Error(
-          `A packaging is for the primary key ${JSON.stringify(bundle)} is already defined.`);
+      throw new Error(`bundle ${JSON.stringify(bundle)} already defined`);
     }
     bundleToModules[bundle] = [...modules];
     for (const module of modules) {

--- a/server.js
+++ b/server.js
@@ -59,18 +59,6 @@ const escapeNonAlphanumerics = (text, exceptions) => text && text.replace(
 // look like HTML (e.g. `require.define`, `requireForKey("key").define`).
 const JSONP_CALLBACK_EXPRESSION = /^[a-zA-Z0-9$:._'"\\()[\]{}]+$/;
 
-const mixin = (...objects) => {
-  const object = {};
-  for (const o of objects) {
-    for (const key in o) {
-      if (hasOwnProperty(o, key)) {
-        object[key] = o[key];
-      }
-    }
-  }
-  return object;
-};
-
 const selectProperties = (o, keys) => {
   const object = {};
   for (let i = 0, ii = keys.length; i < ii; i++) {
@@ -252,7 +240,7 @@ Server.prototype = new function () {
       // Something has gone wrong.
     }
 
-    const requestHeaders = mixin({
+    const requestHeaders = Object.assign({
       'user-agent': 'yajsml',
       'accept': '*/*',
     }, selectProperties(request.headers, ['if-modified-since', 'cache-control']));

--- a/server.js
+++ b/server.js
@@ -151,23 +151,15 @@ class Server {
     if (options.rootURI) {
       this._rootURI = trailingSlash(options.rootURI);
       validateURI(this._rootURI);
-      if (options.rootPath || options.rootPath === '') {
-        this._rootPath = options.rootPath.toString();
-      } else {
-        this._rootPath = 'root';
-      }
-      this._rootPath = leadingSlash(trailingSlash(this._rootPath));
+      const {rootPath = 'root'} = options;
+      this._rootPath = leadingSlash(trailingSlash(rootPath));
     }
 
     if (options.libraryURI) {
       this._libraryURI = trailingSlash(options.libraryURI);
       validateURI(this._rootURI);
-      if (options.libraryPath || options.libraryPath === '') {
-        this._libraryPath = options.libraryPath.toString();
-      } else {
-        this._libraryPath = 'library';
-      }
-      this._libraryPath = leadingSlash(trailingSlash(this._libraryPath));
+      const {libraryPath = 'library'} = options;
+      this._libraryPath = leadingSlash(trailingSlash(libraryPath));
     }
 
     if (this._rootPath && this._libraryPath &&

--- a/server.js
+++ b/server.js
@@ -164,7 +164,7 @@ class Server {
 
     if (options.libraryURI) {
       this._libraryURI = trailingSlash(options.libraryURI);
-      validateURI(this._rootURI);
+      validateURI(this._libraryURI);
       const {libraryPath = 'library'} = options;
       this._libraryPath = leadingSlash(trailingSlash(libraryPath));
     }

--- a/server.js
+++ b/server.js
@@ -23,7 +23,7 @@
 'use strict';
 
 const path = require('path');
-const requestURI = require('./request').requestURI;
+const {requestURI, requestURIs} = require('./request');
 
 const HEADER_WHITELIST =
     ['date', 'last-modified', 'expires', 'cache-control', 'content-type'];
@@ -175,9 +175,7 @@ class Server {
 
     // Some clients insist on transforming values, but cannot run transformation
     // on a separate service. This enables a workaround #hack.
-    if (options.requestURIs) {
-      this._requestURIs = options.requestURIs;
-    }
+    this._requestURIs = options.requestURIs || requestURIs;
   }
 
   _resourceURIForModulePath(path) {

--- a/server.js
+++ b/server.js
@@ -22,6 +22,7 @@
 
 'use strict';
 
+const path = require('path');
 const requestURI = require('./request').requestURI;
 
 const HEADER_WHITELIST =
@@ -45,43 +46,7 @@ const relativePath = (path, rootPath) => {
   return relative + pathSplit.slice(i).join('/');
 };
 
-// Normal `path.normalize` uses backslashes on Windows, so this is a custom
-// implimentation, sigh.
-const normalizePath = (path) => {
-  const pathComponents1 = path.split('/');
-  const pathComponents2 = [];
-
-  let component;
-  for (let i = 0, ii = pathComponents1.length; i < ii; i++) {
-    component = pathComponents1[i];
-    switch (component) {
-      case '':
-        if (i === ii - 1) {
-          pathComponents2.push(component);
-          break;
-        }
-        // Fall through:
-      case '.':
-        if (i === 0) {
-          pathComponents2.push(component);
-        }
-        break;
-      case '..':
-        if (pathComponents2.length > 1 ||
-            (pathComponents2.length === 1 &&
-             pathComponents2[0] !== '' &&
-             pathComponents2[0] !== '.')) {
-          pathComponents2.pop();
-          break;
-        }
-        // Fall through:
-      default:
-        pathComponents2.push(component);
-    }
-  }
-
-  return pathComponents2.join('/');
-};
+const normalizePath = path.posix.normalize;
 
 // OSWASP Guidlines: escape all non alphanumeric characters in ASCII space.
 const escapeNonAlphanumerics = (text, exceptions) => text && text.replace(

--- a/server.js
+++ b/server.js
@@ -266,14 +266,9 @@ class Server {
           return;
         }
 
-        let modulePaths = [modulePath];
-        let preferredPath = modulePath;
-        if (this._associator) {
-          if (this._associator.preferredPath) {
-            preferredPath = this._associator.preferredPath(preferredPath);
-          }
-          modulePaths = this._associator.associatedModulePaths(modulePath);
-        }
+        const preferredPath = this._associator && this._associator.preferredPath
+          ? this._associator.preferredPath(modulePath)
+          : modulePath;
 
         if (preferredPath !== modulePath) {
           let location;
@@ -300,6 +295,9 @@ class Server {
           return;
         }
 
+        const modulePaths = this._associator
+          ? this._associator.associatedModulePaths(modulePath)
+          : [modulePath];
         const resourceURIs = modulePaths.map((m) => this._resourceURIForModulePath(m));
 
         // TODO: Uh, conditional GET?

--- a/server.js
+++ b/server.js
@@ -336,13 +336,13 @@ class Server {
               await this._requestURIs(resourceURIs, 'GET', requestHeadersForGet);
           const status = statuss.reduce((m, s) => m && m === s ? m : undefined);
           const headers = mergeHeaders(...headerss);
-          const moduleMap = Object.fromEntries(
-              modulePaths.map((m, i) => [m, statuss[i] === 200 ? contents[i] : null]));
-          const content = packagedDefine(JSONPCallback, moduleMap);
           if (request.method === 'HEAD') {
             // I'll respond with no content
             respond(status, headers);
           } else if (request.method === 'GET') {
+            const moduleMap = Object.fromEntries(
+                modulePaths.map((m, i) => [m, statuss[i] === 200 ? contents[i] : null]));
+            const content = packagedDefine(JSONPCallback, moduleMap);
             respond(status, headers, content);
           }
         }

--- a/server.js
+++ b/server.js
@@ -255,12 +255,12 @@ class Server {
       const JSONPCallback = url.searchParams.get('callback');
       if (JSONPCallback.length === 0) {
         response.writeHead(400, {'content-type': 'text/plain; charset=utf-8'});
-        response.write('400: The parameter `callback` must be non-empty.');
+        response.write("400: The 'callback' parameter must be non-empty.");
         response.end();
         return;
       } else if (!JSONPCallback.match(JSONP_CALLBACK_EXPRESSION)) {
         response.writeHead(400, {'content-type': 'text/plain; charset=utf-8'});
-        response.write(`400: The parameter \`callback\` must match ${JSONP_CALLBACK_EXPRESSION}.`);
+        response.write(`400: The 'callback' parameter must match ${JSONP_CALLBACK_EXPRESSION}.`);
         response.end();
         return;
       }


### PR DESCRIPTION
Multiple commits:
* Use `path.posix.normalize()` instead of own invention
* Use `Object.assign()` instead of own invention
* Limit iteration to own properties
* Readability improvements
* Simplify options processing
* Tweak error message wording
* Restore default `requestURIs()` function
* Promisify `Server.handle()` to improve readability
* Don't generate content if it won't be used
* Inline `respond()` helper function to improve readability
* Don't compute module paths if not needed
* Fix `relativePath()`
* Fix wrong URI passed to `validateURI()`
